### PR TITLE
Fix reorder error layout by adding the column

### DIFF
--- a/app/Http/Controllers/Backend/SeriesClipsController.php
+++ b/app/Http/Controllers/Backend/SeriesClipsController.php
@@ -94,7 +94,7 @@ class SeriesClipsController extends Controller
 
     public function listClips(Series $series): Factory|View|Application
     {
-        $clips = Clip::select('id', 'title', 'slug', 'episode')
+        $clips = Clip::select('id', 'title', 'slug', 'episode', 'is_public')
             ->where('series_id', $series->id)
             ->addSelect(
                 [

--- a/resources/views/components/list-clips.blade.php
+++ b/resources/views/components/list-clips.blade.php
@@ -222,8 +222,14 @@
                             <div class="w-1/12">
                                 @if ($reorder)
                                     <label>
-                                        <input class="w-1/2" type="number" name="episodes[{{$clip->id}}]"
-                                               value="{{$clip->episode}}">
+                                        <input class="w-1/2 dark:text-black" type="number"
+                                               name="episodes[{{$clip->id}}]"
+                                               value="{{$loop->index + 1}}"
+                                        >
+                                        <div class="col-start-2 col-end-6">
+                                            <p class="mt-2 w-full text-sm text-green-500 dark:text-green-200">
+                                                Actual episode: {{ $clip->episode }}</p>
+                                        </div>
                                     </label>
                                     @error('episodes')
                                     <p class="mt-2 w-full text-xs text-red-500">{{ $message }}</p>
@@ -308,7 +314,7 @@
                         </div>
                     @endforelse
                     @if($reorder)
-                        <div class="pt-10">
+                        <div class="pt-10 space-x-4">
                             <x-button class="bg-blue-600 hover:bg-blue-700">
                                 Reorder Series clips
                             </x-button>


### PR DESCRIPTION
- Used the not public clip list item, because the is_public column was not selected